### PR TITLE
Makefile and printf gcc warning fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ EXECUTABLE=m65dbg
 all: $(SOURCES) $(EXECUTABLE)
 
 $(EXECUTABLE): $(OBJECTS)
-	$(CC) $(LDFLAGS) $(OBJECTS) -o $@
+	$(CC) $(OBJECTS) $(LDFLAGS) -o $@
 
 .c.o:
 	$(CC) $(CFLAGS) $< -o $@

--- a/commands.c
+++ b/commands.c
@@ -876,7 +876,7 @@ void cmdStep(void)
 	{
 		if (autocls)
 			cmdClearScreen();
-		printf(inbuf);
+		printf("%s", inbuf);
 		cmdDisassemble();
 	}
 }
@@ -924,7 +924,7 @@ void cmdNext(void)
 		{
 			if (autocls)
 				cmdClearScreen();
-			printf(inbuf);
+			printf("%s", inbuf);
 			cmdDisassemble();
 		}
 	}

--- a/main.c
+++ b/main.c
@@ -63,7 +63,7 @@ void parse_command(void)
   {
     serialWrite(strInput);
     serialRead(inbuf, BUFSIZE);
-    printf(inbuf);
+    printf("%s", inbuf);
   }
   
   if (strInput != NULL)


### PR DESCRIPTION
Just two rather small changes:

At least on Linux, with the old Makefile, m65dbg cannot be built because -lreadline should put after the object files. I can't test this on Windows/Cygwin, since I don't have them, but it fixes the build on my Linux box at least :)

printf() shouldn't be used with only a string, without a format, as the string can contain even %... sequences, and at least causes GCC warnings as well.
