### PR TITLE
didn't compile on debian 8, fixed that

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ else
 endif
 
 CC=gcc
-CFLAGS=-c -Wall -g
+CFLAGS=-c -Wall -g -std=c99
 SOURCES=main.c serial.c commands.c gs4510.c
 OBJECTS=$(SOURCES:.c=.o)
 EXECUTABLE=m65dbg

--- a/commands.c
+++ b/commands.c
@@ -1,3 +1,4 @@
+#define _BSD_SOURCE _BSD_SOURCE
 #include <stdio.h>
 #include <string.h>
 #include <dirent.h>

--- a/main.c
+++ b/main.c
@@ -2,6 +2,7 @@
  * m65dbg - An enhanced remote serial debugger/monitor for the mega65 project
  **/
 
+#define _BSD_SOURCE _BSD_SOURCE
 #include <stdio.h>
 #include <string.h>
 #include <readline/readline.h>

--- a/serial.c
+++ b/serial.c
@@ -6,9 +6,11 @@
 // it's better to leave commented out by default ...
 //#define SUPPORT_UNIX_DOMAIN_SOCKET
 
+#define _BSD_SOURCE _BSD_SOURCE
 #include <errno.h>
 #include <fcntl.h> 
 #include <string.h>
+#include <strings.h>
 #include <termios.h>
 #include <unistd.h>
 #include <stdio.h>


### PR DESCRIPTION
Some C functions needed the macro _BSD_SOURCE define, or else some headers will not include all prototypes needed. Also the language must be set to C99.
