### PR TITLE
Solve link error on Ubuntu 22.04 LTS: Undefined reference to symbol 'pow@@GLIBC_2.29'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ endif
 CC=gcc
 CFLAGS=-c -Wall -g -std=c99
 COPT=	-I/opt/homebrew/include -L/opt/homebrew/lib -I /usr/include
-LDFLAGS+=-lpng
+LDFLAGS+=-lpng -lm
 SOURCES=main.c serial.c commands.c gs4510.c screen_shot.c m65.c mega65_ftp.c ftphelper.c
 OBJECTS=$(SOURCES:.c=.o)
 EXECUTABLE=m65dbg


### PR DESCRIPTION
Add math library to linker flags.

This solves the following link error (on Ubuntu 22.04 LTS): "
/usr/bin/ld: commands.o: undefined reference to symbol 'pow@@GLIBC_2.29' "