### PR TITLE
Add M65DBG_DEV environemnt variable to override default device.

### DIFF
--- a/main.c
+++ b/main.c
@@ -296,6 +296,11 @@ int main(int argc, char** argv)
   signal(SIGINT, ctrlc_handler);
   rl_initialize();
 
+  if(getenv("M65DBG_DEV") != NULL) {
+     strcpy(devSerial, getenv("M65DBG_DEV")); 
+  }
+
+
   printf("m65dbg - " VERSION "\n");
   printf("======\n");
 


### PR DESCRIPTION
This checks the environment variable M65DBG_DEV and if present, uses it's value for devSerial (the default serial device).

This allows override from the default /dev/ttyUSB1 and avoid having to use the -l option. (I always forget to).  The normal -l and --device options are still available and can be used to override the environment variable. 

